### PR TITLE
Launch elasticsearch from dockerhub

### DIFF
--- a/01-intro/README.md
+++ b/01-intro/README.md
@@ -105,7 +105,7 @@ docker run -it \
     -p 9300:9300 \
     -e "discovery.type=single-node" \
     -e "xpack.security.enabled=false" \
-    docker.elastic.co/elasticsearch/elasticsearch:8.4.3
+    elasticsearch:8.4.3
 ```
 
 Index settings:

--- a/01-intro/README.md
+++ b/01-intro/README.md
@@ -105,6 +105,19 @@ docker run -it \
     -p 9300:9300 \
     -e "discovery.type=single-node" \
     -e "xpack.security.enabled=false" \
+    docker.elastic.co/elasticsearch/elasticsearch:8.4.3
+```
+
+If the previous command doesn't work (i.e. you see "error pulling image configuration"), try to run ElasticSearch directly from Docker Hub:
+
+```bash
+docker run -it \
+    --rm \
+    --name elasticsearch \
+    -p 9200:9200 \
+    -p 9300:9300 \
+    -e "discovery.type=single-node" \
+    -e "xpack.security.enabled=false" \
     elasticsearch:8.4.3
 ```
 


### PR DESCRIPTION
I've slightly changed the code for launching elasticsearch from dockerhub. This way is more universal because docker.elastic.co restricts access for some users.