### PR TITLE
Update requirements.txt to add httpx 0.27.2

### DIFF
--- a/04-monitoring/app/requirements.txt
+++ b/04-monitoring/app/requirements.txt
@@ -5,6 +5,6 @@ python-dotenv
 openai==1.35.7
 sentence-transformers==2.7.0
 numpy==1.26.4
-
+httpx==0.27.2
 --find-links https://download.pytorch.org/whl/cpu/torch_stable.html
 torch==2.3.1+cpu


### PR DESCRIPTION
The latest version of httpx has an incompatibility with OpenAI lib because `proxies` argument is deprecated in newest versions of httpx.