### PR TITLE
Update README.md

### DIFF
--- a/01-intro/README.md
+++ b/01-intro/README.md
@@ -34,7 +34,7 @@ What we will do:
 * Alternative: installing anaconda or miniconda
 
 ```bash
-pip install tqdm notebook==7.1.2 openai elasticsearch pandas scikit-learn ipywidgets
+pip install tqdm notebook==7.1.2 openai elasticsearch==8.13.0 pandas scikit-learn ipywidgets
 ```
 
 ## 1.3 Retrieval


### PR DESCRIPTION
was getting this error BadRequestError(400, 'media_type_header_exception', 'Invalid media-type value on headers [Content-Type, Accept]', Accept version must be either version 8 or 7, but found 9. Accept=application/vnd.elasticsearch+json; compatible-with=9)  same issue while executing esclient.info() coz i had 9.x version elastic search installed and my docker container has 8.x version. So, I downgraded my elasticsearch version to 8.x version same as docker container