### PR TITLE
docs: fix the spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can follow the course at your own pace:
 
 - Vector search and embeddings
 - Indexing and retrieving data efficiently
-- Using Qdrant as the vestor database
+- Using Qdrant as the vector database
 
 
 #### [Workshop: Open-Source Data Ingestion](cohorts/2025/workshops/dlt.md)


### PR DESCRIPTION
Fixed the spelling mistake from 'vestor' to 'vector' in "Using Qdrant as the vector database".