### PR TITLE
`feat(chat): add source citations to qdrant course assistant`

### DIFF
--- a/04-monitoring/chat_starter_qdrant/README.MD
+++ b/04-monitoring/chat_starter_qdrant/README.MD
@@ -69,8 +69,13 @@ Prerequisites
     - "What is the scope of the ml Zoomcamp course?"
     - "How long is the course?"
     - "Do I need to submit homework each week?"
-- Observe responses and check that answers reference ingested documents.
+- Observe responses and check that answers include inline citations such as `[1]`.
+- Expand the `Sources` section under each assistant response to inspect the retrieved supporting chunks.
 - Streamlit default: http://localhost:8501
+
+Citation support
+- The chat app now expects source metadata in Qdrant payloads and renders a `Sources` section for each answer.
+- If your collection was created before this change, re-run `python documents_extraction.py` so existing points get the new citation metadata fields.
 
 7) Evaluation (push reference, QA quality, hallucination in RAG)
 - Run evaluation scripts included in the repo:

--- a/04-monitoring/chat_starter_qdrant/chat.py
+++ b/04-monitoring/chat_starter_qdrant/chat.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from config import QDRANT_HOST, COLLECTION_NAME
-from tools import SearchTool, QdrantVectorStore, build_context, OpenAIClient
+from tools import SearchTool, QdrantVectorStore, build_context, format_citations, OpenAIClient
 import os
 from openinference.instrumentation.openai import OpenAIInstrumentor
 from tracing import tracer
@@ -16,11 +16,14 @@ sv = SearchTool(client=qv.client,
                 collection_name=COLLECTION_NAME)
     
 dev_prompt_template = """
-You are a course assistant, and your goal is to answer questions of students, where QUESTION is provided below and CONTEXT is provided most of the times. 
+You are a course assistant, and your goal is to answer questions of students, where QUESTION is provided below and CONTEXT is provided most of the times.
 Rules:
 * Answer the QUESTION based on the CONTEXT.
 * Use only the facts from the CONTEXT.
-* If CONTEXT is empty, please let the student know, the information about their query is not there, however you found the following information on the web, by searching the web
+* If you use information from the CONTEXT, add inline citations like [1] or [2] that match the numbered sources.
+* If the answer needs more than one source, cite each relevant claim.
+* If CONTEXT is empty or does not contain the answer, say that clearly and do not invent citations.
+* Do not mention any source number that is not present in CONTEXT.
 
 QUESTION: {question}
 
@@ -36,9 +39,15 @@ if "messages" not in st.session_state:
 if "prompts" not in st.session_state:
     st.session_state.prompts = []
 
+if "latest_citations" not in st.session_state:
+    st.session_state.latest_citations = []
+
 for message in st.session_state.messages:
     with st.chat_message(message["role"]):
         st.markdown(message["content"])
+        if message["role"] == "assistant" and message.get("citations"):
+            with st.expander("Sources"):
+                st.markdown(format_citations(message["citations"]))
 
 if user_input := st.chat_input("Ask a question..."):
     with st.chat_message("user response"):
@@ -56,15 +65,28 @@ if user_input := st.chat_input("Ask a question..."):
                                             filter_value="mlops-zoomcamp")
         if search_results:
             llm_span.set_attribute("search.result.text", search_results[0].payload["text"])
-            context = build_context(search_results)
+            context, citations = build_context(search_results)
             prompt = dev_prompt_template.format(question=user_input, context=context)
             llm_span.set_attribute("llm.prompt", prompt)
+            llm_span.set_attribute("search.citations", format_citations(citations))
             st.session_state.prompts.append({"role": "user", "content": prompt})
+            st.session_state.latest_citations = citations
+        else:
+            st.session_state.latest_citations = []
      
         with st.chat_message("assistant"):
             client = OpenAIClient(api_key=os.getenv("OPENAI_API_KEY"), model=MODEL)
             stream = client.chat_stream(messages=st.session_state.prompts)
             response = st.write_stream(stream)
-            st.session_state.messages.append({"role": "assistant", "content": response})
+            if st.session_state.latest_citations:
+                with st.expander("Sources"):
+                    st.markdown(format_citations(st.session_state.latest_citations))
+            st.session_state.messages.append(
+                {
+                    "role": "assistant",
+                    "content": response,
+                    "citations": st.session_state.latest_citations,
+                }
+            )
             llm_span.set_attribute("llm.output.preview", response[:100])
             llm_span.set_attribute("output.value", response)

--- a/04-monitoring/chat_starter_qdrant/documents_extraction.py
+++ b/04-monitoring/chat_starter_qdrant/documents_extraction.py
@@ -76,7 +76,12 @@ def upsert_documents(client, collection_name: str, model_handle_dense: str, mode
                 payload={
                     "text": doc["text"],
                     "section": doc["section"],
-                    "course": course['course']
+                    "question": doc.get("question", ""),
+                    "course": course["course"],
+                    "source_title": doc.get("question") or doc["section"],
+                    "source_section": doc["section"],
+                    "source_course": course["course"],
+                    "chunk_id": f"{course['course']}::{doc['section']}::{doc.get('question', '')}"
                 }
             )
         for course in documents for doc in course["documents"]

--- a/04-monitoring/chat_starter_qdrant/tools.py
+++ b/04-monitoring/chat_starter_qdrant/tools.py
@@ -5,6 +5,7 @@ import os
 from config import QDRANT_HOST, COLLECTION_NAME
 from openinference.semconv.trace import SpanAttributes, OpenInferenceSpanKindValues
 from tracing import tracer
+
 class Tools:
 
     def __init__(self):
@@ -131,26 +132,67 @@ class OpenAIClient:
 
 def build_context(result):
     """
-    Builds a context string from the provided documents.
-    
+    Builds a numbered context string and a matching citations list.
+
     Args:
-        documents (list): List of documents to build the context from.
-        
+        result (list): Retrieved Qdrant points.
+
     Returns:
-        str: A formatted string containing the context from the documents.
+        tuple[str, list[dict]]: Context string and source metadata ordered by citation number.
     """
-    context = ""
-    for point in result:
-        if isinstance(point, tuple):
-            for doc in point[1]:
-                context += f"Section: {doc.payload['section']}\nanswer: {doc.payload['text']}\n\n"
-                course = doc.payload['course']
-        else:
-            doc = point.payload
-            context += f"Section: {doc['section']}\nanswer: {doc['text']}\n\n"
-            course = doc['course']
-    context = f"Course: {course}" + "\n\n" + context
-    return context
+    context_parts = []
+    citations = []
+    course = None
+
+    for index, point in enumerate(result, start=1):
+        payload = point.payload if hasattr(point, "payload") else point
+        if not payload:
+            continue
+
+        course = payload.get("course", course)
+        source_title = payload.get("source_title") or payload.get("question") or payload.get("section", "Unknown source")
+        source_section = payload.get("source_section") or payload.get("section", "Unknown section")
+        source_course = payload.get("source_course") or payload.get("course", "Unknown course")
+        chunk_id = payload.get("chunk_id") or f"{source_course}::{source_section}::{index}"
+
+        context_parts.append(
+            "\n".join(
+                [
+                    f"[{index}]",
+                    f"Title: {source_title}",
+                    f"Section: {source_section}",
+                    f"Course: {source_course}",
+                    f"Content: {payload['text']}",
+                ]
+            )
+        )
+        citations.append(
+            {
+                "index": index,
+                "title": source_title,
+                "section": source_section,
+                "course": source_course,
+                "chunk_id": chunk_id,
+                "text": payload["text"],
+            }
+        )
+
+    course_line = f"Course: {course}\n\n" if course else ""
+    context = course_line + "\n\n".join(context_parts)
+    return context, citations
+
+
+def format_citations(citations):
+    if not citations:
+        return ""
+
+    lines = []
+    for citation in citations:
+        lines.append(
+            f"[{citation['index']}] {citation['title']} | "
+            f"Section: {citation['section']} | Course: {citation['course']}"
+        )
+    return "\n".join(lines)
 
 class SearchTool:
     


### PR DESCRIPTION
Adds citation support to the Qdrant-backed course assistant so responses can be grounded in retrieved source chunks.

This PR updates ingestion to store richer source metadata for each document chunk, including title, section, course, question, and a stable chunk identifier. The chat flow now builds numbered retrieval context blocks, instructs the LLM to use inline references like [1], and renders a matching Sources section in the UI for each assistant response. The README was also updated to document the new citation behavior and note that existing Qdrant collections should be re-ingested to populate the new metadata fields.

Verification:

Python syntax compilation passed for the updated chat starter files.
Citation helper logic was exercised with a focused runtime check and produced the expected numbered context and formatted source list.
Notes:

A full end-to-end Streamlit run still depends on a working local Qdrant instance, valid OpenAI credentials, and re-ingestion of the collection after this metadata change.