### PR TITLE
Add missing RAGBase class definition to RAG helper example

### DIFF
--- a/01-agentic-rag/lessons/08-rag-helper.md
+++ b/01-agentic-rag/lessons/08-rag-helper.md
@@ -93,9 +93,10 @@ CONTEXT:
 """.strip()
 ```
 
-Now the class:
+Now the class: `RAGBase`
 
 ```python
+class RAGBase:
 
     def __init__(
         self,


### PR DESCRIPTION

<img width="1102" height="610" alt="Screenshot 2026-06-09 174159" src="https://github.com/user-attachments/assets/55e6679a-b2e3-4b1d-a1df-22bfb528f2c4" />


## Changes

- Add the missing `class RAGBase:` declaration in the `rag_helper.py` example

## Why

The lesson later uses, imports and instantiates `RAGBase`: class but it was not defined and content of class were directly written without creating class with no mention of class name.

```python
from rag_helper import RAGBase

assistant = RAGBase(...)