### PR TITLE
Allow sqlite ingest to be run multipletimes without duplicate records

### DIFF
--- a/01-agentic-rag/code/ingest.py
+++ b/01-agentic-rag/code/ingest.py
@@ -18,6 +18,9 @@ def load_faq_data():
 
         documents.extend(course_data)
 
+    for doc in documents:
+        doc["doc_id"] = doc.pop("id") #we do this so we can add the id key to sqlite so we don't reimport the same records
+
     return documents
 
 

--- a/01-agentic-rag/code/persistent_rag_ingest.ipynb
+++ b/01-agentic-rag/code/persistent_rag_ingest.ipynb
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "acb9a3f0",
    "metadata": {},
    "outputs": [],
@@ -45,6 +45,7 @@
     "index = TextSearchIndex(\n",
     "    text_fields=['question', 'section', 'answer'],\n",
     "    keyword_fields=['course'],\n",
+    "    id_field=\"doc_id\",      # <-- use the existing id so if it's re-run, it will update existing records instead of creating duplicates\n",
     "    db_path='faq.db'\n",
     ")"
    ]


### PR DESCRIPTION
sqlitesearch doesn't account for ingesting items multiple times. By providing the id_field and changing the name of the json "id" (which is a reserved keyword) to "doc_id", we can run the ingest as many times as we want and it won't create a new record each time if it was already imported.