### PR TITLE
Add dotenv import and load function for env variables

### DIFF
--- a/01-agentic-rag/lessons/09-data-ingestion.md
+++ b/01-agentic-rag/lessons/09-data-ingestion.md
@@ -141,8 +141,10 @@ rest of the code stays the same:
 ```python
 from rag_helper import RAGBase
 from openai import OpenAI
+from dotenv import load_dotenv
 
 openai_client = OpenAI()
+load_dotenv()
 
 assistant = RAGBase(
     index=sqlite_index,


### PR DESCRIPTION
When I created a new notebook for this persistent rag, I got an error because .env was not loaded. Adding the load_dotenv() code block so the code can be run as-is.