### PR TITLE
Moved changed logic from Ingest.py into persistent_rag_ingest.ipynb

### DIFF
--- a/01-agentic-rag/code/ingest.py
+++ b/01-agentic-rag/code/ingest.py
@@ -18,9 +18,6 @@ def load_faq_data():
 
         documents.extend(course_data)
 
-    for doc in documents:
-        doc["doc_id"] = doc.pop("id") #we do this so we can add the id key to sqlite so we don't reimport the same records
-
     return documents
 
 

--- a/01-agentic-rag/code/persistent_rag_ingest.ipynb
+++ b/01-agentic-rag/code/persistent_rag_ingest.ipynb
@@ -20,7 +20,7 @@
     {
      "data": {
       "text/plain": [
-       "79"
+       "85"
       ]
      },
      "execution_count": 2,
@@ -45,14 +45,14 @@
     "index = TextSearchIndex(\n",
     "    text_fields=['question', 'section', 'answer'],\n",
     "    keyword_fields=['course'],\n",
-    "    id_field=\"doc_id\",      # <-- use the existing id so if it's re-run, it will update existing records instead of creating duplicates\n",
+    "    id_field='doc_id',      # <-- use the existing id so if it's re-run, it will update existing records instead of creating duplicates\n",
     "    db_path='faq.db'\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "91f7d013",
    "metadata": {},
    "outputs": [
@@ -146,6 +146,7 @@
     "import time\n",
     "\n",
     "for doc in docs_llm:\n",
+    "    doc['doc_id'] = doc.pop('id') # \"id\" is already a reserved column in sqlite, need to add the ids from the json as a different field name\n",
     "    index.add(doc)\n",
     "    print(f'Added: {doc[\"question\"][:60]}...')\n",
     "    time.sleep(0.5)"
@@ -172,7 +173,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "llm-zoomcamp-2026-code",
+   "display_name": "llm-zoomcamp (3.12.1)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
I previously made a PR to prevent duplicate records from being imported into SQLite databases. The "id" column is reserved in the db, and we need to store each record's id (from the retrieved JSON) in order to see if it's been imported before or not. If it exists, the record won't be imported again to the SQLite database. However I put the logic in ingest.py. It modified the json stored in the response from load_faq_data() to change the "id" column to "doc_id". However I did not realize that the same "ingest.py" file was going to be used in future modules. When I ran the code for Module 4 lesson 2, there is a line in the notebook that prints the "id" from the json. Since I had changed "id" to "doc_id", it errored out. 

The solution was to move the logic into the persistent_rag_ingest.ipynb file instead. Now the field only switches from id to doc_id right before being inserted into the database.