### PR TITLE
Feat: Fix module Prerequisites callouts

### DIFF
--- a/01-agentic-rag/lessons/02-environment.md
+++ b/01-agentic-rag/lessons/02-environment.md
@@ -41,12 +41,20 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 Create an empty folder for the project and initialize it:
 
 ```bash
-mkdir llm-zoomcamp-2026-code
+git clone https://github.com/DataTalksClub/llm-zoomcamp.git llm-zoomcamp-2026-code
 cd llm-zoomcamp-2026-code
 uv init
 ```
 
 This creates a `pyproject.toml` and a basic project structure.
+
+Because you cloned the course repo, you have two ways to work
+through each module. You can create your own files inside the
+module folder (for example `01-agentic-rag/`) and write the code
+yourself as you follow along with the lessons - this is the best
+way to learn. And if you get stuck, the finished code is already
+there in that module's `code/` folder, so you can review it and
+compare it with your own.
 
 ## Creating the project on GitHub Codespaces
 

--- a/02-vector-search/lessons/01-intro.md
+++ b/02-vector-search/lessons/01-intro.md
@@ -89,12 +89,12 @@ In module 1 we set up a project with several libraries. Here we also
 install sentence-transformers. It pulls in PyTorch and is heavy, so I
 recommend a fresh project (a separate Codespace) for this module alone.
 
-If you're starting from scratch, create a new project and install the
+If you're starting from scratch, clone the course repo and install the
 module 1 libraries:
 
 ```bash
-mkdir llm-zoomcamp-code
-cd llm-zoomcamp-code
+git clone https://github.com/DataTalksClub/llm-zoomcamp.git llm-zoomcamp-2026-code
+cd llm-zoomcamp-2026-code
 uv init
 uv add requests minsearch openai jupyter python-dotenv
 ```

--- a/04-evaluation/lessons/01-intro.md
+++ b/04-evaluation/lessons/01-intro.md
@@ -18,6 +18,25 @@ also the most tedious. But it's the only way to be sure your system
 works. And it's how you keep it working as you change prompts and swap
 models.
 
+## Prerequisites
+
+This module builds on the project from module 1. On top of those
+libraries, we use pandas and tqdm here.
+
+If you're starting from scratch, clone the course repo and install the
+dependencies for this module:
+
+```bash
+git clone https://github.com/DataTalksClub/llm-zoomcamp.git llm-zoomcamp-2026-code
+cd llm-zoomcamp-2026-code
+uv init
+uv add requests minsearch openai jupyter python-dotenv pandas tqdm
+```
+
+You also need a `.env` file with your API key. See the
+[module 1 environment setup](../../01-agentic-rag/lessons/02-environment.md)
+for details.
+
 ## The evaluation setup
 
 For search evaluation, we need a dataset of questions where we know

--- a/05-monitoring/lessons/01-intro.md
+++ b/05-monitoring/lessons/01-intro.md
@@ -38,4 +38,23 @@ We focus on RAG here. Monitoring an agent works almost the same way, so
 we leave it as homework. The [agents module](../../01-agentic-rag/)
 already has the pieces you need to apply these same ideas there.
 
+## Prerequisites
+
+This module builds on the project from module 1. On top of those
+libraries, we use psycopg (the PostgreSQL driver) and Streamlit here.
+
+If you're starting from scratch, clone the course repo and install the
+dependencies for this module:
+
+```bash
+git clone https://github.com/DataTalksClub/llm-zoomcamp.git llm-zoomcamp-2026-code
+cd llm-zoomcamp-2026-code
+uv init
+uv add requests minsearch openai jupyter python-dotenv "psycopg[binary]" streamlit
+```
+
+You also need a `.env` file with your API key. See the
+[module 1 environment setup](../../01-agentic-rag/lessons/02-environment.md)
+for details.
+
 [← Back to module](../) | [Assistant →](02-assistant-setup.md)

--- a/06-best-practices/lessons/01-intro.md
+++ b/06-best-practices/lessons/01-intro.md
@@ -36,6 +36,25 @@ Here are the five techniques we'll cover:
 In this module, we'll focus on hybrid search and reranking. These
 two techniques give the biggest improvement for the least effort.
 
+## Prerequisites
+
+This module uses Elasticsearch for hybrid search and
+sentence-transformers for embeddings. sentence-transformers pulls in
+PyTorch and is heavy, so I recommend a fresh project (a separate
+Codespace) for this module alone.
+
+Clone the course repo and install the dependencies for this module:
+
+```bash
+git clone https://github.com/DataTalksClub/llm-zoomcamp.git llm-zoomcamp-2026-code
+cd llm-zoomcamp-2026-code
+uv init
+uv add jupyter sentence-transformers elasticsearch langchain langchain-elasticsearch pandas tqdm
+```
+
+You also need Elasticsearch running locally (at `http://localhost:9200`)
+to follow along with the hybrid search and reranking examples.
+
 Slides: [llm-zoomcamp-best-practicies.pdf](../llm-zoomcamp-best-practicies.pdf)
 
 To learn more:


### PR DESCRIPTION
# Fix module Prerequisites callouts

Cleaned up the Prerequisites callouts across the later modules so each one lists the dependencies it actually uses, instead of the copy-pasted module 2 boilerplate.

- 04-evaluation and 05-monitoring — dropped the "installs sentence-transformers / PyTorch is heavy / use a separate Codespace" warning (neither module uses it) and corrected the uv add lines: pandas + tqdm for evaluation, psycopg[binary] + streamlit for monitoring.
- 06-best-practices — kept the PyTorch warning since this module really does use sentence-transformers, but fixed the install command to the real stack (elasticsearch, langchain, langchain-elasticsearch, etc.) and swapped the .env note for an Elasticsearch-running requirement.
- 03-orchestration — reads better now: removed the clone/uv block entirely. It's a Kestra/YAML module that doesn't touch the Python libraries, and pointing people at cloning the repo there was misleading since module 3 has no Python code/ dir to clone for — just the flows/. Its existing Kestra/GCP/YAML prerequisites stand on their own.