### PR TITLE
fix: wrap tool_calls in json.dumps to escape special characters

### DIFF
--- a/04-evaluation/lessons/14-agent-evaluation.md
+++ b/04-evaluation/lessons/14-agent-evaluation.md
@@ -179,7 +179,7 @@ agent_result = {
     "question": rec["question"],
     "answer_agent": result.last_message,
     "answer_orig": answer_orig,
-    "tool_calls": tool_calls,
+    "tool_calls": json.dumps(tool_calls),
     "cost": result.cost.total_cost,
     "document": doc_id,
 }
@@ -188,7 +188,9 @@ agent_result
 ```
 
 The `answer_agent` field is what we evaluate with the LLM judge. The
-`tool_calls` field lets the judge see how the agent got there.
+`tool_calls` field lets the judge see how the agent got there. 
+Wrap `tool_calls` with `json.dumps` to properly escape special characters,
+such as double quotes.
 
 ## Processing multiple questions
 
@@ -207,7 +209,7 @@ def generate_agent_answer(rec):
         "question": rec["question"],
         "answer_agent": result.last_message,
         "answer_orig": original_doc["answer"],
-        "tool_calls": tool_calls,
+        "tool_calls": json.dumps(tool_calls),
         "cost": result.cost.total_cost,
         "document": doc_id,
     }


### PR DESCRIPTION
## Summary

This PR serializes `tool_calls` with `json.dumps()` before writing agent answers to CSV.

## Cause

`tool_calls` is originally a Python list of dictionaries. When saved directly through `pandas.to_csv()`, it is written as a Python-style string representation using single quotes, for example:

```python
[{'name': 'search', 'arguments': '{"query":"..."}'}]
```

This is not valid JSON.

## Issue Fixed

Later, the evaluation step reads `tool_calls` from the CSV and tries to parse it with `json.loads()`. Because the stored value is not valid JSON, parsing fails with:

```text
JSONDecodeError: Expecting property name enclosed in double quotes
```

Using `json.dumps(tool_calls)` before writing the CSV stores the field as valid JSON, allowing `json.loads()` to parse it correctly during evaluation.