### PR TITLE
Load environment variables using dotenv

### DIFF
--- a/cohorts/2026/05-monitoring/starter.py
+++ b/cohorts/2026/05-monitoring/starter.py
@@ -10,6 +10,9 @@ from minsearch import Index
 
 from rag_helper import RAGBase
 
+from dotenv import load_dotenv
+load_dotenv()
+
 COMMIT = "8c1834d"
 
 # --- Load the course lessons (same as HW1, HW2, HW4) ---


### PR DESCRIPTION
In starter.py while creating openAI client, it throws OpenAIerror. So corrected the code to load environment variables

 Traceback (most recent call last):
  File "/workspaces/llm-zoomcamp/05-monitoring/starter.py", line 28, in <module>
    client = OpenAI()
             ^^^^^^^^
  File "/workspaces/llm-zoomcamp/.venv/lib/python3.12/site-packages/openai/_client.py", line 194, in __init__
    raise OpenAIError(
openai.OpenAIError: Missing credentials. Please pass an `api_key`, `workload_identity`, `admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable.
