### PR TITLE
fix: load environment variables before initializing OpenAI client in data ingestion example

### DIFF
--- a/01-agentic-rag/lessons/09-data-ingestion.md
+++ b/01-agentic-rag/lessons/09-data-ingestion.md
@@ -143,8 +143,8 @@ from rag_helper import RAGBase
 from openai import OpenAI
 from dotenv import load_dotenv
 
-openai_client = OpenAI()
 load_dotenv()
+openai_client = OpenAI()
 
 assistant = RAGBase(
     index=sqlite_index,


### PR DESCRIPTION
The OpenAI client initialization was happening before load_dotenv(),
which meant the OPENAI_API_KEY wasn't loaded from the .env file.

This could cause an authentication error. Moved load_dotenv() to the
correct position, right after imports and before creating the client.